### PR TITLE
feat: Header with fixed position [SCSE-134]

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,7 +31,7 @@ const Header = () => {
   }, []);
 
   return (
-    <Flex py={4} px={{ base: 4, md: 4, lg: 16 }} align="center">
+    <Flex pos="sticky" zIndex={2} bg="#dedee0" top={0} py={4} px={{ base: 4, md: 4, lg: 16 }} align="center">
       <HStack spacing={2}>
         <RouterLink to={routes.HOME}>
           <Flex alignItems="center">


### PR DESCRIPTION
First of all, the 'sticky' attribute does not work. So I used 'fixed' as a workaround. For this purpose, I added an extra box behind the header to pad all the contents below.
Kindly refer to the following link:
https://github.com/chakra-ui/chakra-ui/issues/3605