### PR TITLE
fix: Add zero padding to price displays

### DIFF
--- a/src/utils/functions/currency.ts
+++ b/src/utils/functions/currency.ts
@@ -1,5 +1,7 @@
-export const displayPrice = (cents: number): string => {
-  const centsStr = cents.toString()
-  const priceStr = centsStr.slice(0, -2).concat(".").concat(centsStr.slice(-2))
+export const displayPrice = (amountInCents: number): string => {
+  const amountStr = amountInCents.toString()
+  const dollarStr = amountStr.slice(0, -2).padStart(1, '0') 
+  const centStr = amountStr.slice(-2).padStart(2, '0') 
+  const priceStr = dollarStr.concat(".").concat(centStr)
   return `$${priceStr}`
 }


### PR DESCRIPTION
This commit adds appropriate zero padding to price displays, allowing the checkout and cart to display $0.00 instead of $.0

[SCSE-157]