### PR TITLE
fix: standardise image heights in merchandise list [SCSE-169] 

### DIFF
--- a/src/pages/Cart/CartItem.tsx
+++ b/src/pages/Cart/CartItem.tsx
@@ -89,7 +89,13 @@ const CartItem: React.FC<CartItemProps> = ({ isMobile, data, onRemove, onQuantit
     <Grid templateColumns="3fr repeat(4, 1fr)" rowGap={2}>
       <GridItem display="flex">
         <Box boxShadow="sm" maxWidth={[125, 100]}>
-          <Image w="100%" borderRadius="md" src={productInfo?.images?.[0]} fallbackSrc="https://via.placeholder.com/100" />
+          <Image 
+            src={productInfo?.images?.[0]} 
+            fallbackSrc="https://via.placeholder.com/100" 
+            boxSize="70"
+            objectFit="contain"
+            borderRadius="md" 
+          />
         </Box>
         <Flex flexDir="column" fontWeight="600" fontSize={["sm", "md"]} ml={2}>
           <Text color="primary.600" noOfLines={2}>

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -72,7 +72,13 @@ export const Checkout: FC = () => {
           const subtotal = (product?.price ?? -1) * item.quantity;
           return (
             <Flex key={item.productId.toString()} mt={[4, 6]}>
-              <Image src={product?.images?.[0]} h={70} w={70} borderRadius="md" />
+              <Image 
+                src={product?.images?.[0]} 
+                fallbackSrc="https://via.placeholder.com/100" 
+                boxSize="70"
+                objectFit="contain"
+                borderRadius="md" 
+              />
               <Flex flexDirection="column" flex={1} ml={2}>
                 <Flex justifyContent="space-between" alignItems="flex-start">
                   <Text fontWeight={500} noOfLines={2}>

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -31,7 +31,7 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
             maxHeight="300" 
             boxSize='300px'
             objectFit='contain'
-            fallbackSrc="https://via.placeholder.com/100" 
+            fallbackSrc="https://via.placeholder.com/300" 
           />
           <Box p={2}>
             <Flex

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -25,7 +25,14 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
           overflow="hidden"
           _groupHover={{ boxShadow: "xl" }}
         >
-          <Image src={imgSrc} w="100%" maxHeight="300" fallbackSrc="https://via.placeholder.com/150" />
+          <Image 
+            src={imgSrc} 
+            boxSize='300px'
+            objectFit='contain'
+            // w="100%" 
+            // maxHeight="300" 
+            fallbackSrc="https://via.placeholder.com/300" 
+          />
           <Box p={2}>
             <Flex
               justifyContent="space-between"

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -27,10 +27,11 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
         >
           <Image 
             src={imgSrc} 
+            w="100%" 
+            maxHeight="300" 
             boxSize='300px'
             objectFit='contain'
-            align="center center"
-            fallbackSrc="https://via.placeholder.com/300" 
+            fallbackSrc="https://via.placeholder.com/100" 
           />
           <Box p={2}>
             <Flex

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -1,5 +1,5 @@
 import { ArrowForwardIcon } from "@chakra-ui/icons";
-import { Box, Image, Text, GridItem, Flex, Badge, AspectRatio } from "@chakra-ui/react";
+import { Box, Image, Text, GridItem, Flex, Badge, AspectRatio, Center } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 import routes from "../../utils/constants/routes";
 import { displayPrice } from "../../utils/functions/currency";
@@ -25,13 +25,14 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
           overflow="hidden"
           _groupHover={{ boxShadow: "xl" }}
         >
-          <AspectRatio maxH='300px' ratio={1}>
+          <Center>
             <Image 
               src={imgSrc} 
               fallbackSrc="https://via.placeholder.com/300" 
+              boxSize="300"
               objectFit='contain'
             />
-          </AspectRatio>
+          </Center>
           <Box p={2}>
             <Flex
               justifyContent="space-between"

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -1,5 +1,5 @@
 import { ArrowForwardIcon } from "@chakra-ui/icons";
-import { Box, Image, Text, GridItem, Flex, Badge } from "@chakra-ui/react";
+import { Box, Image, Text, GridItem, Flex, Badge, AspectRatio } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 import routes from "../../utils/constants/routes";
 import { displayPrice } from "../../utils/functions/currency";
@@ -25,14 +25,13 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
           overflow="hidden"
           _groupHover={{ boxShadow: "xl" }}
         >
-          <Image 
-            src={imgSrc} 
-            w="100%" 
-            maxHeight="300" 
-            boxSize='300px'
-            objectFit='contain'
-            fallbackSrc="https://via.placeholder.com/300" 
-          />
+          <AspectRatio maxH='300px' ratio={1}>
+            <Image 
+              src={imgSrc} 
+              fallbackSrc="https://via.placeholder.com/300" 
+              objectFit='contain'
+            />
+          </AspectRatio>
           <Box p={2}>
             <Flex
               justifyContent="space-between"

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -29,8 +29,6 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
             src={imgSrc} 
             boxSize='300px'
             objectFit='contain'
-            // w="100%" 
-            // maxHeight="300" 
             fallbackSrc="https://via.placeholder.com/300" 
           />
           <Box p={2}>

--- a/src/pages/MerchandiseList/Card.tsx
+++ b/src/pages/MerchandiseList/Card.tsx
@@ -29,6 +29,7 @@ const Card = ({ productId, imgSrc, text, price, sizeRange, isOutOfStock }: CardP
             src={imgSrc} 
             boxSize='300px'
             objectFit='contain'
+            align="center center"
             fallbackSrc="https://via.placeholder.com/300" 
           />
           <Box p={2}>


### PR DESCRIPTION
use prop `object-fit: contain` to ensure cards are the same size regardless of image size