### PR TITLE
fix: order summary display on mobile [SCSE-204]

### DIFF
--- a/src/pages/OrderSummary/OrderSummary.tsx
+++ b/src/pages/OrderSummary/OrderSummary.tsx
@@ -79,19 +79,19 @@ export const OrderSummary: FC = () => {
         overflow="hidden"
         flexDir="column"
       >
-        <Show below="lg">
+        <Show below="md">
           <Flex justifyContent="space-between">
-            <Flex flexDir="column">
-              <Flex alignItems="center" gap={4}>
+            <Flex flexDir="column" w="100%">
+              <Flex alignItems="center" gap={6}>
                 <Heading size="md">Order Number</Heading>
                 <Badge width="fit-content">
                   {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
                 </Badge>
               </Flex>
-              <Heading size="lg" mt={2}>
+              <Heading size="lg">
                 {orderState?.orderID.split("-")[0]}
               </Heading>
-              <Flex alignItems="center">
+              <Flex alignItems="center" mb={2}>
                 <Text fontSize="sm">{orderState?.orderID}</Text>
               </Flex>
               <Text fontSize="sm" color="grey">
@@ -108,16 +108,16 @@ export const OrderSummary: FC = () => {
             </Flex>
           </Flex>
         </Show>
-        <Hide below="lg">
+        <Hide below="md">
           <Flex justifyContent="space-between">
             <Flex flexDir="column">
-              <Flex alignItems="center" gap={4}>
+              <Flex alignItems="center" gap={6}>
                 <Heading size="md">Order Number</Heading>
                 <Badge width="fit-content">
                   {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
                 </Badge>
               </Flex>
-              <Heading size="lg" mt={2}>
+              <Heading size="lg" mb={2}>
                 {orderState?.orderID.split("-")[0]}
               </Heading>
               <Flex alignItems="center">

--- a/src/pages/OrderSummary/OrderSummary.tsx
+++ b/src/pages/OrderSummary/OrderSummary.tsx
@@ -14,7 +14,7 @@ import {
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import OrderItem from "../../components/OrderItem";
-import { renderOrderStatus } from "../../utils/constants/order-status";
+import { renderOrderStatus, getOrderStatusColor } from "../../utils/constants/order-status";
 import { QueryKeys } from "../../utils/constants/queryKeys";
 import { api } from "../../services/api";
 import { OrderStatusType, OrderType } from "../../typings/order";
@@ -82,12 +82,15 @@ export const OrderSummary: FC = () => {
         <Show below="md">
           <Flex justifyContent="space-between">
             <Flex flexDir="column" w="100%">
-              <Flex alignItems="center" gap={6}>
-                <Heading size="md">Order Number</Heading>
-                <Badge width="fit-content">
-                  {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
-                </Badge>
-              </Flex>
+              <Badge 
+                width="fit-content" 
+                fontSize="sm" 
+                mb={2} 
+                color={getOrderStatusColor(orderState?.status ?? OrderStatusType.DELAY)}
+              >
+                {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
+              </Badge>
+              <Heading size="md">Order Number</Heading>
               <Heading size="lg">
                 {orderState?.orderID.split("-")[0]}
               </Heading>
@@ -113,7 +116,11 @@ export const OrderSummary: FC = () => {
             <Flex flexDir="column">
               <Flex alignItems="center" gap={6}>
                 <Heading size="md">Order Number</Heading>
-                <Badge width="fit-content">
+                <Badge 
+                  width="fit-content" 
+                  fontSize="sm" 
+                  color={getOrderStatusColor(orderState?.status ?? OrderStatusType.DELAY)}
+                >
                   {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
                 </Badge>
               </Flex>

--- a/src/pages/OrderSummary/OrderSummary.tsx
+++ b/src/pages/OrderSummary/OrderSummary.tsx
@@ -8,6 +8,8 @@ import {
   Divider,
   Image,
   Badge,
+  Show,
+  Hide,
 } from "@chakra-ui/react";
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -77,33 +79,64 @@ export const OrderSummary: FC = () => {
         overflow="hidden"
         flexDir="column"
       >
-        <Flex justifyContent="space-between">
-          <Flex flexDir="column">
-            <Flex alignItems="center" gap={4}>
-              <Heading size="md">Order Number</Heading>
-              <Badge width="fit-content">
-                {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
-              </Badge>
-            </Flex>
-            <Heading size="lg" mt={2}>
-              {orderState?.orderID.split("-")[0]}
-            </Heading>
-            <Flex alignItems="center">
-              <Text fontSize="sm">{orderState?.orderID}</Text>
+        <Show below="lg">
+          <Flex justifyContent="space-between">
+            <Flex flexDir="column">
+              <Flex alignItems="center" gap={4}>
+                <Heading size="md">Order Number</Heading>
+                <Badge width="fit-content">
+                  {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
+                </Badge>
+              </Flex>
+              <Heading size="lg" mt={2}>
+                {orderState?.orderID.split("-")[0]}
+              </Heading>
+              <Flex alignItems="center">
+                <Text fontSize="sm">{orderState?.orderID}</Text>
+              </Flex>
+              <Text fontSize="sm" color="grey">
+                Order date:{" "}
+                {orderState
+                  ? new Date(`${orderState.orderDateTime}Z`).toLocaleString(
+                      "en-sg"
+                    )
+                  : ""}
+              </Text>
+              <Text fontSize="sm" color="grey">
+                Last update: {orderState?.lastUpdate}
+              </Text>
             </Flex>
           </Flex>
-          <Flex flexDir="column" fontSize="sm" color="grey">
-            <Text>
-              Order date:{" "}
-              {orderState
-                ? new Date(`${orderState.orderDateTime}Z`).toLocaleString(
-                    "en-sg"
-                  )
-                : ""}
-            </Text>
-            <Text>Last update: {orderState?.lastUpdate}</Text>
+        </Show>
+        <Hide below="lg">
+          <Flex justifyContent="space-between">
+            <Flex flexDir="column">
+              <Flex alignItems="center" gap={4}>
+                <Heading size="md">Order Number</Heading>
+                <Badge width="fit-content">
+                  {renderOrderStatus(orderState?.status ?? OrderStatusType.DELAY)}
+                </Badge>
+              </Flex>
+              <Heading size="lg" mt={2}>
+                {orderState?.orderID.split("-")[0]}
+              </Heading>
+              <Flex alignItems="center">
+                <Text fontSize="sm">{orderState?.orderID}</Text>
+              </Flex>
+            </Flex>
+            <Flex flexDir="column" fontSize="sm" color="grey">
+              <Text>
+                Order date:{" "}
+                {orderState
+                  ? new Date(`${orderState.orderDateTime}Z`).toLocaleString(
+                      "en-sg"
+                    )
+                  : ""}
+              </Text>
+              <Text>Last update: {orderState?.lastUpdate}</Text>
+            </Flex>
           </Flex>
-        </Flex>
+        </Hide>
         <Divider my={4} />
         {orderState?.orderItems.map((item) => (
           <OrderItem data={item} isMobile={isMobile} />


### PR DESCRIPTION
Display order number/status/order date on individual rows for smaller screens